### PR TITLE
Fix destructuring invite params

### DIFF
--- a/src/com/ractiveware/biff_plugins_auth/plugins/monolith.clj
+++ b/src/com/ractiveware/biff_plugins_auth/plugins/monolith.clj
@@ -419,8 +419,8 @@
                     [single-opt-in
                      new-user-tx
                      enable-passwords
-                     password-conforms?
-                     params]
+                     password-conforms?]
+                    :keys [params] 
                     :as ctx}
                    invite-code email]
   (let [password (normalize-password params)]


### PR DESCRIPTION
Due to incorrect destructuring, `params` was always empty, resulting in an empty password.